### PR TITLE
Add image placeholder handling in report generation and parsing

### DIFF
--- a/server/backend/helpers/generate-report.js
+++ b/server/backend/helpers/generate-report.js
@@ -84,6 +84,9 @@ name=PAYLOAD&description=PAYLOAD
 
 Upon admin review in \`[VULNERABLE_ENDPOINT]\`, the script executed in the admin’s browser, confirming the blind XSS.
 
+Screenshot of the page showing the executed script:
+{IMAGE_PLACERHOLDER} 
+
 ---
 
 ### **Mitigation Recommendations**
@@ -154,7 +157,7 @@ async function generateReport(xssAlertId){
         input: [
             {
                 "role": "developer",
-                "content": `Generate a detailed vulnerability report from user input based the following report example.\n\n${exampleReport}\n\nThe report should be in markdown format and include the following information:\n- Vulnerability Type\n- Injection Point\n- Trigger Point\n- Impact\n- Severity\n- Proof of Concept\n- Mitigation Recommendations\n- Conclusion\n\nOutput should be in JSON. Ex: {"report": "## XSS Report ..etc"}`
+                "content": `Generate a detailed vulnerability report from user input based the following report example.\n\n${exampleReport}\n\nThe report should be in markdown format and include the following information:\n- Vulnerability Type\n- Injection Point\n- Trigger Point\n- Impact\n- Severity\n- Proof of Concept\n- Mitigation Recommendations\n- Conclusion\nInclude '{IMAGE_PLACERHOLDER}' in the markdown to attach the screenshot later.\n\nOutput should be in JSON. Ex: {"report": "## XSS Report ..etc"}`
             },
             {
                 "role": "user",

--- a/server/frontend/src/views/Alert.vue
+++ b/server/frontend/src/views/Alert.vue
@@ -492,7 +492,13 @@ const parseMarkdown = () => {
   }
 
   if (alert.value['Report']) {
-    reportSourceParsed.value = marked.parse(alert.value['Report']['description']);
+    // Replace {IMAGE_PLACERHOLDER} with markdown image
+    const markPrep = alert.value['Report']['description'].replace(
+      '{IMAGE_PLACERHOLDER}',
+      `  \n![Screenshot](/api/alerts/${alert.value.id}/screenshot)`
+    );
+    console.log(markPrep);
+    reportSourceParsed.value = marked.parse(markPrep);
     const bgColor = '#18181b';
     reportSourceParsed.value = `
         <html>


### PR DESCRIPTION
This pull request introduces changes to enhance the vulnerability report generation and display process by including placeholders for screenshots in the report and replacing them with actual image links in the frontend. These changes improve the clarity and usability of the generated reports.

### Enhancements to report generation:

* Updated the report content template in `generateReport` to include `{IMAGE_PLACERHOLDER}` as a marker for attaching screenshots in the markdown report. This ensures that reports can later include visual proof of vulnerabilities. (`server/backend/helpers/generate-report.js`, [server/backend/helpers/generate-report.jsL157-R160](diffhunk://#diff-aeebed83d4b85293aa4f098564fc6e00a29a8d84ef04974dc5053166ad6a57f5L157-R160))

### Improvements to report rendering:

* Modified the `parseMarkdown` function in the frontend to replace `{IMAGE_PLACERHOLDER}` with a markdown image link pointing to the screenshot URL. This dynamically integrates screenshots into the rendered report. (`server/frontend/src/views/Alert.vue`, [server/frontend/src/views/Alert.vueL495-R501](diffhunk://#diff-1bcd345d30130776911345d5b91dd74be03b3825b0677af3f6841023f41d526eL495-R501))

### Additional content updates:

* Added a placeholder for a screenshot in the proof-of-concept section of the report template to guide users in attaching visual evidence. (`server/backend/helpers/generate-report.js`, [server/backend/helpers/generate-report.jsR87-R89](diffhunk://#diff-aeebed83d4b85293aa4f098564fc6e00a29a8d84ef04974dc5053166ad6a57f5R87-R89))